### PR TITLE
Fix/rename service

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -122,7 +122,7 @@ define github_actions_runner::instance (
     }),
     require => [File["${github_actions_runner::root_dir}/${instance_name}/configure_install_runner.sh"],
                 Exec["${instance_name}-run_configure_install_runner.sh"]],
-    notify  => Service["github-actions-runner-${instance_name}"],
+    notify  => Service["github-actions-runner.${instance_name}.service"],
   }
 
   $ensure_service = $ensure ? {
@@ -135,7 +135,7 @@ define github_actions_runner::instance (
     'absent'  => false,
   }
 
-  service { "github-actions-runner-${instance_name}":
+  service { "github-actions-runner.${instance_name}.service":
     ensure  => $ensure_service,
     enable  => $enable_service,
     require => Class['systemd::systemctl::daemon_reload'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Telefonica-github_actions_runner",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Shimon Ohayon",
   "summary": "Module to configure our GitHub Actions runner on Debian hosts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Aligning the service title as the same name of the unit file - will fix the service start issue.
```
[TUENTI] [root@jenkinsslave-prod-8 /etc/systemd/system]$ puppet agent --enable; puppet agent -vt --environment=fix_actions_runner_services_names;puppet agent --disable
Info: Using configured environment 'fix_actions_runner_services_names'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for jenkinsslave-prod-8.tuenti.int
Info: Applying configuration version '1602848251'
Notice: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[tf-module-kubenovum]/Service[github-actions-runner.tf-module-kubenovum.service]/ensure: ensure changed 'stopped' to 'running' (corrective)
Info: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[tf-module-kubenovum]/Service[github-actions-runner.tf-module-kubenovum.service]: Unscheduling refresh on Service[github-actions-runner.tf-module-kubenovum.service]
Notice: Applied catalog in 10.63 seconds
```