### PR TITLE
Support GitHub Enterprise Server self-hosted Actions

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,4 +9,5 @@ github_actions_runner::personal_access_token: 'PAT'
 github_actions_runner::user: 'root'
 github_actions_runner::group: 'root'
 github_actions_runner::instances: {}
-
+github_actions_runner::github_domain: "https://github.com"
+github_actions_runner::github_api: "https://api.github.com"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,8 @@ class github_actions_runner (
   String                    $user,
   String                    $group,
   Hash[String, Hash]        $instances,
+  String                    $github_domain,
+  String                    $github_api,
 ) {
 
   $root_dir = "${github_actions_runner::base_dir_name}-${github_actions_runner::package_ensure}"

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,7 +40,8 @@ define github_actions_runner::instance (
   String                    $instance_name         = $title,
   Optional[Array[String]]   $labels                = undef,
   Optional[String]          $repo_name             = undef,
-
+  String                    $github_domain         = $github_actions_runner::github_domain,
+  String                    $github_api            = $github_actions_runner::github_api,
 ) {
 
   if $labels {
@@ -51,13 +52,17 @@ define github_actions_runner::instance (
   }
 
   $url = $repo_name ? {
-    undef => "https://github.com/${org_name}",
-    default => "https://github.com/${org_name}/${repo_name}",
+    undef => "${github_domain}/${org_name}",
+    default => "${github_domain}/${org_name}/${repo_name}",
   }
 
-  $token_url = $repo_name ? {
-    undef => "https://api.github.com/repos/${org_name}/actions/runners/registration-token",
-    default => "https://api.github.com/repos/${org_name}/${repo_name}/actions/runners/registration-token",
+  if $repo_name {
+    $token_url = "${github_api}/repos/${org_name}/${repo_name}/actions/runners/registration-token"
+  } else {
+    $token_url = $github_api ? {
+      'https://api.github.com' => "${github_api}/repos/${org_name}/actions/runners/registration-token",
+      default => "${github_api}/orgs/${org_name}/actions/runners/registration-token",
+    }
   }
 
   $archive_name =  "${github_actions_runner::package_name}-${github_actions_runner::package_ensure}.tar.gz"


### PR DESCRIPTION
The Github.com API and Github Enterprise Server API differ on base path and organization requests.

https://docs.github.com/en/enterprise-server@2.22/rest/reference/actions#create-a-registration-token-for-an-organization

In GHES case these settings should be all that's needed.

```
github_actions_runner::github_domain: "https://git.example.com"
github_actions_runner::github_api: "https://git.example.com/api/v3"
```