### PR TITLE
Fix non-root run permissions

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -80,6 +80,8 @@ define github_actions_runner::instance (
   archive { "${instance_name}-${archive_name}":
     ensure       => $ensure,
     path         => "/tmp/${instance_name}-${archive_name}",
+    user         => $user,
+    group        => $group,
     source       => $source,
     extract      => true,
     extract_path => "${github_actions_runner::root_dir}/${instance_name}",
@@ -107,6 +109,7 @@ define github_actions_runner::instance (
   }
 
   exec { "${instance_name}-run_configure_install_runner.sh":
+    user        => $user,
     cwd         => "${github_actions_runner::root_dir}/${instance_name}",
     command     => "${github_actions_runner::root_dir}/${instance_name}/configure_install_runner.sh",
     refreshonly => true


### PR DESCRIPTION
Without this, non-root `user` or `group` results in a mix of permissions.

```
ll /mnt/ghe_actions-2.272.0/DevOps/
total 80
drwxr-xr-x 5   1001 docker  4096 Dec  3 23:40 ./
drwxr-xr-x 3 ubuntu ubuntu  4096 Dec  3 23:40 ../
-rw-r--r-- 1 root   root     225 Dec  3 23:40 .credentials
-rw------- 1 root   root    1667 Dec  3 23:40 .credentials_rsaparams
-rw-r--r-- 1 root   root      13 Dec  3 23:40 .env
-rw-r--r-- 1 root   root     139 Dec  3 23:40 .path
-rw-r--r-- 1 root   root     317 Dec  3 23:40 .runner
drwxr-xr-x 2 root   root    4096 Dec  3 23:40 _diag/
drwxr-xr-x 3   1001 docker 16384 Jul 29 19:35 bin/
-rwxr-xr-x 1   1001 docker  2673 Jul 29 19:33 config.sh*
-rwxr-xr-x 1 ubuntu ubuntu  1237 Dec  3 23:40 configure_install_runner.sh*
-rwxr-xr-x 1   1001 docker   623 Jul 29 19:33 env.sh*
drwxr-xr-x 4   1001 docker  4096 Jul 29 19:34 externals/
-rwxr-xr-x 1   1001 docker  1666 Jul 29 19:33 run.sh*
-rwxr-xr-x 1 root   root     513 Dec  3 23:40 runsvc.sh*
-rwxr-xr-x 1 root   root    4650 Dec  3 23:40 svc.sh*
```