### PR TITLE
Add self hosted support (cont. from #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ github_actions_runner::instances:
       - self-hosted-custom1
 ```
 
+In case you are using Github Enterprise Server , you can define these two parameters to specify the correct urls:
+```yaml
+github_actions_runner::github_domain: "https://git.example.com"
+github_actions_runner::github_api: "https://git.example.com/api/v3"
+```
+
 ## Limitations
 
 Tested on Debian 9 stretch hosts only.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,4 +9,5 @@ github_actions_runner::personal_access_token: 'PAT'
 github_actions_runner::user: 'root'
 github_actions_runner::group: 'root'
 github_actions_runner::instances: {}
-
+github_actions_runner::github_domain: "https://github.com"
+github_actions_runner::github_api: "https://api.github.com"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,8 @@ class github_actions_runner (
   String                    $user,
   String                    $group,
   Hash[String, Hash]        $instances,
+  String                    $github_domain,
+  String                    $github_api,
   Optional[String]          $http_proxy = undef,
   Optional[String]          $https_proxy = undef,
   Optional[String]          $no_proxy = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,12 @@
 # * instances
 # Hash[String, Hash], Github Runner Instances to be managed.
 #
+# * github_domain
+# String, Base URL for Github Domain.
+#
+# * github_api
+# String, Base URL for Github API.
+#
 # * http_proxy
 # Optional[String], Proxy URL for HTTP traffic. More information at https://docs.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners.
 #

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -52,7 +52,8 @@ define github_actions_runner::instance (
   Optional[String]          $no_proxy              = $github_actions_runner::no_proxy,
   Optional[Array[String]]   $labels                = undef,
   Optional[String]          $repo_name             = undef,
-
+  String                    $github_domain         = $github_actions_runner::github_domain,
+  String                    $github_api            = $github_actions_runner::github_api,
 ) {
 
   if $labels {
@@ -63,13 +64,17 @@ define github_actions_runner::instance (
   }
 
   $url = $repo_name ? {
-    undef => "https://github.com/${org_name}",
-    default => "https://github.com/${org_name}/${repo_name}",
+    undef => "${github_domain}/${org_name}",
+    default => "${github_domain}/${org_name}/${repo_name}",
   }
 
-  $token_url = $repo_name ? {
-    undef => "https://api.github.com/repos/${org_name}/actions/runners/registration-token",
-    default => "https://api.github.com/repos/${org_name}/${repo_name}/actions/runners/registration-token",
+  if $repo_name {
+    $token_url = "${github_api}/repos/${org_name}/${repo_name}/actions/runners/registration-token"
+  } else {
+    $token_url = $github_api ? {
+      'https://api.github.com' => "${github_api}/repos/${org_name}/actions/runners/registration-token",
+      default => "${github_api}/orgs/${org_name}/actions/runners/registration-token",
+    }
   }
 
   $archive_name =  "${github_actions_runner::package_name}-${github_actions_runner::package_ensure}.tar.gz"


### PR DESCRIPTION
This PR continues the work done in https://github.com/Telefonica/puppet-github-actions-runner/pull/6

Added the missing documentation as well as some tests for the new github domain and api parameters.