### PR TITLE
Fix order when setting a github action runner as absent

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,6 @@ fixtures:
       ref: "v1.1.2"
     systemd:
       repo: "https://github.com/camptocamp/puppet-systemd.git"
-      ref: "1.1.1"
+      ref: "2.7.0"
 
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -141,8 +141,20 @@ define github_actions_runner::instance (
     refreshonly => true
   }
 
+  $active_service = $ensure ? {
+    'present' => true,
+    'absent'  => false,
+  }
+
+  $enable_service = $ensure ? {
+    'present' => true,
+    'absent'  => false,
+  }
+
   systemd::unit_file { "github-actions-runner.${instance_name}.service":
     ensure  => $ensure,
+    enable  => $enable_service,
+    active  => $active_service,
     content => epp('github_actions_runner/github-actions-runner.service.epp', {
       instance_name => $instance_name,
       root_dir      => $github_actions_runner::root_dir,
@@ -154,23 +166,6 @@ define github_actions_runner::instance (
     }),
     require => [File["${github_actions_runner::root_dir}/${instance_name}/configure_install_runner.sh"],
                 Exec["${instance_name}-run_configure_install_runner.sh"]],
-    notify  => Service["github-actions-runner.${instance_name}.service"],
-  }
-
-  $ensure_service = $ensure ? {
-    'present' => running,
-    'absent'  => stopped,
-  }
-
-  $enable_service = $ensure ? {
-    'present' => true,
-    'absent'  => false,
-  }
-
-  service { "github-actions-runner.${instance_name}.service":
-    ensure  => $ensure_service,
-    enable  => $enable_service,
-    require => Class['systemd::systemctl::daemon_reload'],
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "version_requirement": ">= 2.7.0 < 3.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
Bump minor systemd version requirement 2.7.0
https://github.com/camptocamp/puppet-systemd/blob/master/CHANGELOG.md#270-2019-10-29
From now on, service resource is already managed by Systemd::Unit_file

- [x] Tested create a new github action runner and service is managed by puppet
- [x] Tested that setting it as absent, it gets removed the service and files.