### PR TITLE
Add exec to notify config execution in case runsvc.sh does not exist

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -132,6 +132,15 @@ define github_actions_runner::instance (
     require => Archive["${instance_name}-${archive_name}"],
   }
 
+  exec { "${instance_name}-check-runner-configured":
+    user    => $user,
+    cwd     => "${github_actions_runner::root_dir}/${instance_name}",
+    command => "true",
+    unless  => "test -f ${github_actions_runner::root_dir}/${instance_name}/runsvc.sh",
+    path    => ["/bin", "/usr/bin"],
+    notify  => Exec["${instance_name}-run_configure_install_runner.sh"],
+  }
+
   exec { "${instance_name}-ownership":
     user        => $user,
     cwd         => $github_actions_runner::root_dir,


### PR DESCRIPTION
This PR try to solve the issue #18 

Adds a notification to the execution of the config script in case the `runsvc.sh` file does not exist.

Therefore, configure script (configure_install_runner.sh) should be executed in the following two scenarios:
- `configure_install_runner.sh` script is created or updated with new values
- `configure_install_runner.sh` did not finish correctly and it did not create the script `runsvc.sh` inside the bin folder