### PR TITLE
fix: default org only token url

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -72,7 +72,7 @@ define github_actions_runner::instance (
       $url = "${github_domain}/${org_name}/${repo_name}"
     } else {
       $token_url = $github_api ? {
-        'https://api.github.com' => "${github_api}/repos/${org_name}/actions/runners/registration-token",
+        'https://api.github.com' => "${github_api}/orgs/${org_name}/actions/runners/registration-token",
         default => "${github_api}/orgs/${org_name}/actions/runners/registration-token",
       }
       $url = "${github_domain}/${org_name}"

--- a/spec/classes/github_actions_runner_spec.rb
+++ b/spec/classes/github_actions_runner_spec.rb
@@ -175,6 +175,7 @@ describe 'github_actions_runner' do
             },
           )
         end
+
         install_script_content_first_runner = <<~HEREDOC
           #!/bin/bash
           # Configure the action runner after the package file has been downloaded.


### PR DESCRIPTION
# Summary

The default path for the API to retrieve the runner token was calculated incorrectly including 'repos' instead of 'orgs' which causes the token retrieval to fail.

I'm guessing at some point github changed their API from https://api.github.com/**repos**/$org_name/ to https://api.github.com/**orgs**/$org_name/ which broke the behavior of the token_url when no repo is specified.

# Fix Details

* Changes the token_url calculation logic in the `instance` defined type to correctly use **orgs** when no github.com api string override is provided.
* Adds some quick and dirty test code to make sure the creation script is built as expected.