### PR TITLE
Update labels in runs-on to use public github runners

### DIFF
--- a/.github/workflows/pdk-test-unit.yml
+++ b/.github/workflows/pdk-test-unit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validating:
-    runs-on: [self-hosted-novum, self-hosted, linux]
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         puppet-version: [5, 6, 7]
@@ -21,13 +21,10 @@ jobs:
         puppet-version: ${{ matrix.puppet-version }}
 
   testing:
-    runs-on: [self-hosted-novum, self-hosted, linux]
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         puppet-version: [5, 6, 7]
-    if: always()
-    needs:
-    - validating
     steps:
     - name: Clone repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Use github public runners (ubuntu 20.04) for this repository.

Remove `needs` and `if` keys in workflows.
Ticket: LIFE-9292