### PR TITLE
Add new workflow to bump version and create Github Release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,77 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New release version (e.g. 0.8.0 or 0.8.1)"
+        required: true
+
+jobs:
+  set_version:
+    runs-on: [self-hosted-org, linux]
+    steps:
+    - name: Checkout this repo
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
+
+    - name: Update medatata.json version
+      uses: jossef/action-set-json-field@v1
+      with:
+        file: metadata.json
+        field: version
+        value: ${{ github.event.inputs.version }}
+
+    - id: show_diff
+      name: Show git diff
+      run: |
+        git diff
+
+    - name: Commit & Push changes
+      id: push_version
+      uses: EndBug/add-and-commit@v7
+      with:
+        github_token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
+        branch: 'master'
+        message: 'Bump version ${{ github.event.inputs.version }}'
+        author_email: lifecycle-github@telefonica.com
+        author_name: tuentisre
+        push: true
+
+    - name: get version
+      id: get_version
+      uses: notiz-dev/github-action-json-property@release
+      with:
+        path: 'metadata.json'
+        prop_path: 'version'
+
+    - id: show_version
+      name: Show version
+      run: |
+        echo "Release version ${{ steps.get_version.outputs.prop }}"
+        echo "Commit ${{ steps.push_version.outputs.commit_sha }}"
+
+    - id: get_release_notes
+      name: Get release notes
+      run: |
+        response=$(curl -s -X POST \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
+          -d '{"tag_name":"${{ steps.get_version.outputs.prop }}", "target_commitish": "${{ steps.push_version.outputs.commit_sha }}"}')
+        echo "JSON Release notes response:"
+        echo "${response}"
+        echo ::set-output name=releaseNotesJson::${response}
+
+    - id: create_github_release
+      name: Create Github release
+      uses: softprops/action-gh-release@v1
+      with:
+        token: ${{ secrets.NOVUM_PRIVATE_REPOS }}
+        body: "Release ${{steps.get_version.outputs.version }}\n\n${{fromJson(steps.get_release_notes.outputs.releaseNotesJson).body}}"
+        target_commitish: ${{ steps.push_version.outputs.commit_sha }}
+        draft: false
+        prerelease: false
+        tag_name: "${{ steps.get_version.outputs.prop }}"
+        name: "v${{ steps.get_version.outputs.prop }}"


### PR DESCRIPTION
Add a new workflow that is intended to be run once all branches for a release are already merged in the main branch.

This workflow is going to:
- Set the right version in metadata.json
- Create a Github Release with the corresponding release notes (auto-generated).

In a future step, it could be set here the step to publish the tgz into puppet forge.