### PR TITLE
Manage environment PATH in instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module will setup all of the files and configuration needed for GitHub Acti
 
 ### hiera configuration examples
 
-This module supports configuration through hiera. 
+This module supports configuration through hiera.
 
 #### Creating an organization level Actions runner
 
@@ -53,7 +53,7 @@ github_actions_runner::instances:
 ```
 
 Note, your `personal_access_token` has to contain the `repo` permission.
-    
+
 #### Instance level overwrites
 ```yaml
 github_actions_runner::instances:
@@ -88,7 +88,7 @@ github_actions_runner::github_domain: "https://git.example.com"
 github_actions_runner::github_api: "https://git.example.com/api/v3"
 ```
 
-In addition to the runner configuration examples above, you can also configure runners 
+In addition to the runner configuration examples above, you can also configure runners
 on the enterprise level by setting a value for `enterprise_name`, for example:
 ```yaml
 github_actions_runner::ensure: present
@@ -104,6 +104,35 @@ github_actions_runner::instances:
 ```
 
 Note, your `personal_access_token` has to contain the `admin:enterprise` permission.
+
+### Update PATH used by Github Runners
+
+By default, puppet will not modify the values that the runner scripts create when
+the runner is set.
+
+In case you need to use another value of paths in the environment variable PATH,
+you can define through hiera. For example:
+
+- For all runners defined:
+  ```yaml
+  github_actions_runner::path:
+    - /usr/local/bin
+    - /usr/bin
+    - /bin
+    - /my/own/path
+  ```
+- For just a specific runner:
+  ```yaml
+  github_actions_runner::instances:
+    example_org_instance:
+      path:
+        - /usr/local/bin
+        - /usr/bin
+        - /bin
+        - /my/own/path
+      labels:
+        - self-hosted-custom
+  ```
 
 ## Limitations
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,3 +10,7 @@ github_actions_runner::group: 'root'
 github_actions_runner::instances: {}
 github_actions_runner::github_domain: "https://github.com"
 github_actions_runner::github_api: "https://api.github.com"
+github_actions_runner::path:
+  - '/usr/local/bin'
+  - '/usr/bin'
+  - '/bin'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,7 +10,3 @@ github_actions_runner::group: 'root'
 github_actions_runner::instances: {}
 github_actions_runner::github_domain: "https://github.com"
 github_actions_runner::github_api: "https://api.github.com"
-github_actions_runner::path:
-  - '/usr/local/bin'
-  - '/usr/bin'
-  - '/bin'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@
 # Optional[String], Comma separated list of hosts that should not use a proxy. More information at https://docs.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners
 #
 # * path
-# Optional[Array[String]], List of paths to be used as PATH env in the instance runner.
+# Optional[Array[String]], List of paths to be used as PATH env in the instance runner. If not defined, this file will be kept as created by the runner scripts. Default value: undef
 #
 class github_actions_runner (
   Enum['present', 'absent'] $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class github_actions_runner (
   Optional[String[1]]       $http_proxy = undef,
   Optional[String[1]]       $https_proxy = undef,
   Optional[String[1]]       $no_proxy = undef,
-  Optional[Array[String]]   $path,
+  Optional[Array[String]]   $path = undef,
 ) {
 
   $root_dir = "${github_actions_runner::base_dir_name}-${github_actions_runner::package_ensure}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,9 @@
 # * no_proxy
 # Optional[String], Comma separated list of hosts that should not use a proxy. More information at https://docs.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners
 #
+# * path
+# Optional[Array[String]], List of paths to be used as PATH env in the instance runner.
+#
 class github_actions_runner (
   Enum['present', 'absent'] $ensure,
   Stdlib::Absolutepath      $base_dir_name,
@@ -72,6 +75,7 @@ class github_actions_runner (
   Optional[String[1]]       $http_proxy = undef,
   Optional[String[1]]       $https_proxy = undef,
   Optional[String[1]]       $no_proxy = undef,
+  Optional[Array[String]]   $path,
 ) {
 
   $root_dir = "${github_actions_runner::base_dir_name}-${github_actions_runner::package_ensure}"

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -163,14 +163,19 @@ define github_actions_runner::instance (
     onlyif      => "test -d ${github_actions_runner::root_dir}/${instance_name}"
   }
 
+  $content_path = $path ? {
+      undef   => undef,
+      default => epp('github_actions_runner/path.epp', {
+        paths => $path,
+      })
+  }
+
   file { "${github_actions_runner::root_dir}/${name}/.path":
     ensure  => $ensure,
     mode    => '0644',
     owner   => $user,
     group   => $group,
-    content => epp('github_actions_runner/path.epp', {
-      paths => $path,
-    }),
+    content => $content_path,
     require => [Archive["${instance_name}-${archive_name}"],
                 Exec["${instance_name}-run_configure_install_runner.sh"],
     ],

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -41,6 +41,9 @@
 # * labels
 # Optional[Array[String]], A list of costum lables to add to a runner.
 #
+# * path
+# Optional[Array[String]], List of paths to be used as PATH env in the instance runner.
+#
 define github_actions_runner::instance (
   Enum['present', 'absent']  $ensure                = 'present',
   String[1]                  $personal_access_token = $github_actions_runner::personal_access_token,
@@ -57,6 +60,7 @@ define github_actions_runner::instance (
   Optional[String[1]]        $enterprise_name       = $github_actions_runner::enterprise_name,
   Optional[String[1]]        $org_name              = $github_actions_runner::org_name,
   Optional[String[1]]        $repo_name             = undef,
+  Optional[Array[String]]    $path                  = $github_actions_runner::path,
 ) {
 
   if $labels {
@@ -159,6 +163,20 @@ define github_actions_runner::instance (
     onlyif      => "test -d ${github_actions_runner::root_dir}/${instance_name}"
   }
 
+  file { "${github_actions_runner::root_dir}/${name}/.path":
+    ensure  => $ensure,
+    mode    => '0644',
+    owner   => $user,
+    group   => $group,
+    content => epp('github_actions_runner/path.epp', {
+      paths => $path,
+    }),
+    require => [Archive["${instance_name}-${archive_name}"],
+                Exec["${instance_name}-run_configure_install_runner.sh"],
+    ],
+    notify  => Systemd::Unit_file["github-actions-runner.${instance_name}.service"]
+  }
+
   $active_service = $ensure ? {
     'present' => true,
     'absent'  => false,
@@ -183,6 +201,7 @@ define github_actions_runner::instance (
       no_proxy      => $no_proxy,
     }),
     require => [File["${github_actions_runner::root_dir}/${instance_name}/configure_install_runner.sh"],
+                File["${github_actions_runner::root_dir}/${instance_name}/.path"],
                 Exec["${instance_name}-run_configure_install_runner.sh"]],
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -42,7 +42,8 @@
 # Optional[Array[String]], A list of costum lables to add to a runner.
 #
 # * path
-# Optional[Array[String]], List of paths to be used as PATH env in the instance runner.
+# Optional[Array[String]], List of paths to be used as PATH env in the instance runner. If not defined, this file will be kept as created
+#                          by the runner scripts. (Default: Value set by github_actions_runner Class)
 #
 define github_actions_runner::instance (
   Enum['present', 'absent']  $ensure                = 'present',

--- a/spec/classes/github_actions_runner_spec.rb
+++ b/spec/classes/github_actions_runner_spec.rb
@@ -364,8 +364,8 @@ describe 'github_actions_runner' do
             'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'root',
-            'mode'    => '0755',
-            'content' => undef,
+            'mode'    => '0644',
+            'content' => nil,
           )
         end
       end
@@ -385,7 +385,7 @@ describe 'github_actions_runner' do
             'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'root',
-            'mode'    => '0755',
+            'mode'    => '0644',
             'content' => "/usr/bin:/bin\n",
           )
         end
@@ -414,7 +414,7 @@ describe 'github_actions_runner' do
             'ensure'  => 'present',
             'owner'   => 'root',
             'group'   => 'root',
-            'mode'    => '0755',
+            'mode'    => '0644',
             'content' => "/bin:/other/path\n",
           )
         end

--- a/spec/classes/github_actions_runner_spec.rb
+++ b/spec/classes/github_actions_runner_spec.rb
@@ -365,7 +365,7 @@ describe 'github_actions_runner' do
             'owner'   => 'root',
             'group'   => 'root',
             'mode'    => '0755',
-            'content' => "/usr/local/bin:/usr/bin:/bin\n",
+            'content' => undef,
           )
         end
       end

--- a/templates/path.epp
+++ b/templates/path.epp
@@ -1,0 +1,3 @@
+<%- | Array[String] $paths,
+| -%>
+<%= join($paths, ':') %>


### PR DESCRIPTION
In this PR, it is added the support to manage the PATH that will be loaded in the instance runners.

By default, puppet is not going to change the values that are configured by the scripts themselves. They can be seen at: `/path/to/instance/.path` file

If this path needs to be managed by the module, there are two options.
1. Manage for all the instances globally:
   ```yaml
   github_actions_runner::path:
     - /usr/bin
     - /bin
     - /my/own/path
   ```
2. Manage the PATH for just an specific runner:
   ```yaml
   github_actions_runner::instances:
     my_runner:
       path:
         - /usr/local/bin
         - /usr/bin
         - /bin
         - /my/other/path
   ```

Examples:
- Not defining path parameter in hiera at all:
  ```shell
   $ puppet agent -vt --environment no_definition_hiera --noop
  Info: Using configured environment 'no_definition_hiera'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Retrieving locales
  Info: Loading facts
  Info: Applying configuration version '1642159909'
  Notice: Applied catalog in 11.59 seconds
  ```
- Defining the parameter `github_actions_runner::path`:
  ```shell
   $ puppet agent -vt --environment add_path_global --noop
  Info: Using configured environment 'add_path_global'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Retrieving locales
  Info: Loading facts
  Info: Applying configuration version '1642160167'
  Notice: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[repo]/File[/srv/actions-runner-2.272.0/repo/.path]/content: 
  --- /srv/actions-runner-2.272.0/repo/.path	2021-07-19 15:04:07.984325864 +0000
  +++ /tmp/puppet-file20220114-3211-1i6hox9	2022-01-14 11:36:42.303800213 +0000
  @@ -1 +1 @@
  -/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
  +/usr/local/bin:/usr/bin:/bin

  Notice: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[repo]/File[/srv/actions-runner-2.272.0/repo/.path]/content: current_value '{md5}0d32fc448dc20c6f7e63c796b3e6b7b2', should be '{md5}ed5594fd5912a17f6b122007fb7615af' (noop)
  Info: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[repo]/File[/srv/actions-runner-2.272.0/repo/.path]: Scheduling refresh of Systemd::Unit_file[github-actions-runner.repo.service]
  Notice: Systemd::Unit_file[github-actions-runner.repo.service]: Would have triggered 'refresh' from 1 event
  Info: Systemd::Unit_file[github-actions-runner.repo.service]: Scheduling refresh of Service[github-actions-runner.repo.service]
  Notice: /Stage[main]/Github_actions_runner/Github_actions_runner::Instance[repo]/Systemd::Unit_file[github-actions-runner.repo.service]/Service[github-actions-runner.repo.service]: Would have triggered 'refresh' from 1 event
  Notice: Systemd::Unit_file[github-actions-runner.repo.service]: Would have triggered 'refresh' from 1 event
  Notice: Github_actions_runner::Instance[repo]: Would have triggered 'refresh' from 2 events
  Notice: Class[Github_actions_runner]: Would have triggered 'refresh' from 1 event
  Notice: Stage[main]: Would have triggered 'refresh' from 1 event
  Notice: Applied catalog in 12.85 seconds

  ```

   