### PR TITLE
feat: add .env file support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,26 +56,33 @@
 # Optional[String], Comma separated list of hosts that should not use a proxy. More information at https://docs.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners
 #
 # * path
-# Optional[Array[String]], List of paths to be used as PATH env in the instance runner. If not defined, this file will be kept as created by the runner scripts. Default value: undef
+# Optional[Array[String]], List of paths to be used as PATH env in the instance runner.
+#                          If not defined, file ".path" will be kept as created by the runner scripts. Default value: undef
+#
+# * env
+# Optional[Hash[String, String]], List of variables to be used as env variables in the instance runner.
+#                                 If not defined, file ".env" will be kept as created
+#                                 by the runner scripts. (Default: Value set by github_actions_runner Class)
 #
 class github_actions_runner (
-  Enum['present', 'absent'] $ensure,
-  Stdlib::Absolutepath      $base_dir_name,
-  String[1]                 $personal_access_token,
-  String[1]                 $package_name,
-  String[1]                 $package_ensure,
-  String[1]                 $repository_url,
-  String[1]                 $user,
-  String[1]                 $group,
-  Hash[String[1], Hash]     $instances,
-  String[1]                 $github_domain,
-  String[1]                 $github_api,
-  Optional[String[1]]       $enterprise_name = undef,
-  Optional[String[1]]       $org_name = undef,
-  Optional[String[1]]       $http_proxy = undef,
-  Optional[String[1]]       $https_proxy = undef,
-  Optional[String[1]]       $no_proxy = undef,
-  Optional[Array[String]]   $path = undef,
+  Enum['present', 'absent']      $ensure,
+  Stdlib::Absolutepath           $base_dir_name,
+  String[1]                      $personal_access_token,
+  String[1]                      $package_name,
+  String[1]                      $package_ensure,
+  String[1]                      $repository_url,
+  String[1]                      $user,
+  String[1]                      $group,
+  Hash[String[1], Hash]          $instances,
+  String[1]                      $github_domain,
+  String[1]                      $github_api,
+  Optional[String[1]]            $enterprise_name = undef,
+  Optional[String[1]]            $org_name = undef,
+  Optional[String[1]]            $http_proxy = undef,
+  Optional[String[1]]            $https_proxy = undef,
+  Optional[String[1]]            $no_proxy = undef,
+  Optional[Array[String]]        $path = undef,
+  Optional[Hash[String, String]] $env = undef,
 ) {
 
   $root_dir = "${github_actions_runner::base_dir_name}-${github_actions_runner::package_ensure}"

--- a/spec/classes/github_actions_runner_spec.rb
+++ b/spec/classes/github_actions_runner_spec.rb
@@ -370,7 +370,7 @@ describe 'github_actions_runner' do
         end
       end
 
-      context 'is expected to create a .path file in an instance setting path at global level' do
+      context 'is expected to create a .path file in an instance, setting path at global level' do
         let(:params) do
           super().merge(
             'path' => [
@@ -391,7 +391,7 @@ describe 'github_actions_runner' do
         end
       end
 
-      context 'is expected to create a .path file in an instance setting the path at instance level' do
+      context 'is expected to create a .path file in an instance, setting the path at instance level' do
         let(:params) do
           super().merge(
             'path' => [
@@ -416,6 +416,77 @@ describe 'github_actions_runner' do
             'group'   => 'root',
             'mode'    => '0644',
             'content' => "/bin:/other/path\n",
+          )
+        end
+      end
+
+      # .env
+      context 'is expected to create a .env file with a specific requires and notifies' do
+        it do
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env')
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env').that_requires(['Archive[first_runner-actions-runner-linux-x64-2.272.0.tar.gz]',
+                                                                                                           'Exec[first_runner-run_configure_install_runner.sh]'])
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env').that_notifies('Systemd::Unit_file[github-actions-runner.first_runner.service]')
+        end
+      end
+
+      context 'is expected to create a .env file in an instance with default env hash (nil content)' do
+        it do
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env').with(
+            'ensure'  => 'present',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'content' => nil,
+          )
+        end
+      end
+
+      context 'is expected to create a .env file in an instance, setting env at global level' do
+        let(:params) do
+          super().merge(
+            'env' => {
+              'foo' => 'bar',
+              'key' => 'value',
+            },
+          )
+        end
+
+        it do
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env').with(
+            'ensure'  => 'present',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'content' => "foo=bar\nkey=value\n",
+          )
+        end
+      end
+
+      context 'is expected to create a .env file in an instance, setting the env at instance level' do
+        let(:params) do
+          super().merge(
+            'env' => {
+              'foo' => 'bar',
+              'key' => 'value',
+            },
+            'instances' => {
+              'first_runner' => {
+                'env' => {
+                  'other' => 'value',
+                }
+              },
+            },
+          )
+        end
+
+        it do
+          is_expected.to contain_file('/some_dir/actions-runner-2.272.0/first_runner/.env').with(
+            'ensure'  => 'present',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+            'content' => "other=value\n",
           )
         end
       end

--- a/templates/env.epp
+++ b/templates/env.epp
@@ -1,0 +1,5 @@
+<%- | Hash[String, String] $envs,
+| -%>
+<%- $envs.each |$key, $value| { -%>
+<%= $key %>=<%= $value %>
+<%- } -%>


### PR DESCRIPTION
This PR adds the option to add customized environment variables per instance runner.

For instance, it could be used to add the environment variables mentioned in [this doc](https://docs.github.com/en/actions/hosting-your-own-runners/running-scripts-before-or-after-a-job#triggering-the-scripts) to add cleanup scripts in runners.

Issue: https://github.com/Telefonica/puppet-github-actions-runner/issues/39

Adding as an example to the ".env" file the definition of the start hook
```bash
[/srv/actions-runner/repo]$ cat .env 
LANG=en_US.UTF-8
ACTIONS_RUNNER_HOOK_JOB_STARTED=/root/test.sh
```

Content of /root/test.sh
```bash
#!/bin/bash

echo "Testing hooks added by means of .env file"
echo "Current directory"
pwd
```

That variable was read and loaded by the runner, and its executions appears in the step "**Set up runner**" in all workflows:

```
A job started hook has been configured by the self-hosted runner administrator
Run '/root/test.sh'
Testing hooks added by means of .env file
Current directory
/srv/actions-runner/repo/_work/repo/repo
```


As a note, according to the few tests I've carried out, if other variables are added to .env file, they cannot be used as an environment variable in Github workflows.