### PR TITLE
Allow github token to be retrieved from a deferred function

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -131,7 +131,7 @@ define github_actions_runner::instance (
     mode    => '0755',
     owner   => $user,
     group   => $group,
-    content => epp('github_actions_runner/configure_install_runner.sh.epp', {
+    content => stdlib::deferrable_epp('github_actions_runner/configure_install_runner.sh.epp', {
       personal_access_token => $personal_access_token,
       token_url             => $token_url,
       instance_name         => $instance_name,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 8.4.0 < 10.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -1,7 +1,7 @@
 <%- | String $personal_access_token,
       String $token_url,
       String $instance_name,
-      Stdlib::Absolutepath $root_dir,
+      String $root_dir,
       String $url,
       String $hostname,
       String $assured_labels,


### PR DESCRIPTION
This allows you to

```puppet
class{'github_actions_runner':
  personal_access_token => Deferred('secret::get',['poc']),
}
```

for the existing case where a string is used the module will operate in the same way.