### PR TITLE
Support adding runner to runner groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ github_actions_runner::instances:
   example_org_instance:
     labels:
       - self-hosted-custom
+    runner_group: 'MyRunners'
 ```
 
 Note, your `personal_access_token` has to contain the `admin:org` permission.

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -44,6 +44,8 @@
 # * labels
 # Optional[Array[String]], A list of costum lables to add to a runner.
 #
+# * runner_group
+# Optional[String[1]], The github runner group to add the runner to.
 # * path
 # Optional[Array[String]], List of paths to be used as PATH env in the instance runner. If not defined, file ".path" will be kept as created
 #                          by the runner scripts. (Default: Value set by github_actions_runner Class)
@@ -67,6 +69,7 @@ define github_actions_runner::instance (
   Optional[String[1]]            $no_proxy              = $github_actions_runner::no_proxy,
   Optional[Boolean]              $disable_update        = $github_actions_runner::disable_update,
   Optional[Array[String[1]]]     $labels                = undef,
+  Optional[String[1]]            $runner_group          = undef,
   Optional[String[1]]            $enterprise_name       = $github_actions_runner::enterprise_name,
   Optional[String[1]]            $org_name              = $github_actions_runner::org_name,
   Optional[String[1]]            $repo_name             = undef,
@@ -139,6 +142,7 @@ define github_actions_runner::instance (
       url                   => $url,
       hostname              => $hostname,
       assured_labels        => $assured_labels,
+      runner_group          => $runner_group,
       disable_update        => $disable_update,
     }),
     notify  => Exec["${instance_name}-run_configure_install_runner.sh"],

--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -5,6 +5,7 @@
       String $url,
       String $hostname,
       String $assured_labels,
+      Optional[String[1]] $runner_group = undef,
       Boolean $disable_update,
 | -%>
 #!/bin/bash
@@ -33,6 +34,9 @@ export RUNNER_ALLOW_RUNASROOT=true
   --name <%= $hostname %>-<%= $instance_name %>  \
   --url <%= $url %>                              \
   --token ${TOKEN}                               \
+  <%- if $runner_group { -%>
+  --runnergroup <%= $runner_group %>             \
+  <%- } -%>
   <%- if $disable_update { -%>
   --disableupdate                                \
   <%- } -%>


### PR DESCRIPTION
Allow a per instance `runner_group` to be specified to pupulate the `--runnergroup` option to `config.sh`

* https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/managing-access-to-self-hosted-runners-using-groups