### PR TITLE
Use cmp instead of just -f for runsvc.sh

### DIFF
--- a/templates/configure_install_runner.sh.epp
+++ b/templates/configure_install_runner.sh.epp
@@ -39,7 +39,7 @@ export RUNNER_ALLOW_RUNASROOT=true
   <%= $assured_labels %> &>/dev/null
 
 # Copy service endpoint script.
-if [ ! -f <%= $root_dir %>/<%= $instance_name %>/runsvc.sh ]; then
+if ! cmp --silent runsvc.sh <%= $root_dir %>/<%= $instance_name %>/bin/runsvc.sh <%= $root_dir %>/<%= $instance_name %>/runsvc.sh; then
   cp <%= $root_dir %>/<%= $instance_name %>/bin/runsvc.sh <%= $root_dir %>/<%= $instance_name %>/runsvc.sh
   chmod 755 <%= $root_dir %>/<%= $instance_name %>/runsvc.sh
 fi


### PR DESCRIPTION
This fixes #50 

Check to see if the contents of `runsvc.sh` is different to what's contained in `bin` and re-copy it if necessary. This also covers the original case of the file not existing in the first place.

This is important because as github runners self-update that script can change in future releases, which then causes a failure of the service if the file is out of date.